### PR TITLE
Remove code duplicates from UMLEditableComboBox.java

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
@@ -7,5 +8,5 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="corretto-1.8" project-jdk-type="JavaSDK" />
 </project>

--- a/src/argouml-core-umlpropertypanels/src/org/argouml/core/propertypanels/ui/UMLEditableComboBox.java
+++ b/src/argouml-core-umlpropertypanels/src/org/argouml/core/propertypanels/ui/UMLEditableComboBox.java
@@ -305,19 +305,6 @@ public class UMLEditableComboBox extends UMLComboBox implements
             panel.removeActionListener(l);
         }
 
-        /*
-         * @see javax.swing.ComboBoxEditor#selectAll()
-         */
-        public void selectAll() {
-            super.selectAll();
-        }
-
-        /*
-         * @see javax.swing.ComboBoxEditor#getItem()
-         */
-        public Object getItem() {
-            return panel.getText();
-        }
 
     }
 


### PR DESCRIPTION
### Issue Number
Resolves https://github.com/rilling/argoumlFall2024/issues/33

**Summary of Changes**
- Refactored duplicate code blocks in UMLEditableComboBox.java by removing the methods that do not have any implicit calls.
- This change eliminates redundancy and improves code readability.

**Refactoring Approach**
- Using PMD-CPD to identify the duplicate
- Looking for methods that do not have any implicit method calls
- Removing those methods to reduce number of lines of code.