### PR TITLE
[SpotBug] fix: overridable method call inside constructor 

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/Critic.java
+++ b/src/argouml-app/src/org/argouml/cognitive/Critic.java
@@ -265,27 +265,28 @@ public class Critic
      * call {@link Agency#register(Critic, Object)} with that instance.
      */
     public Critic() {
-	/* TODO:  THIS IS A HACK.
-	 * A much better way of doing this would be not to start
-	 * the critic in the first place.
-	 */
-	if (Configuration.getBoolean(getCriticKey(), true)) {
-	    addControlRec(ENABLED, Boolean.TRUE);
-	    isActive = true;
-	} else {
-	    addControlRec(ENABLED, Boolean.FALSE);
-	    isActive = false;
-	}
-	addControlRec(SNOOZE_ORDER, new SnoozeOrder());
-	criticType = "correctness";
-	knowledgeTypes.add(KT_CORRECTNESS);
-	decisionCategory = "Checking";
+        initializeCritic();
+    }
 
-	moreInfoURL = defaultMoreInfoURL();
-	description = Translator.localize("misc.critic.no-description");
-	headline = Translator.messageFormat("misc.critic.default-headline",
-	        new Object[] {getClass().getName()});
-	priority = ToDoItem.MED_PRIORITY;
+
+    private void initializeCritic() {
+        if (Configuration.getBoolean(getCriticKey(), true)) {
+            addControlRec(ENABLED, Boolean.TRUE);
+            isActive = true;
+        } else {
+            addControlRec(ENABLED, Boolean.FALSE);
+            isActive = false;
+        }
+        addControlRec(SNOOZE_ORDER, new SnoozeOrder());
+        criticType = "correctness";
+        knowledgeTypes.add(KT_CORRECTNESS);
+        decisionCategory = "Checking";
+
+        moreInfoURL = defaultMoreInfoURL();
+        description = Translator.localize("misc.critic.no-description");
+        headline = Translator.messageFormat("misc.critic.default-headline",
+                new Object[] {getClass().getName()});
+        priority = ToDoItem.MED_PRIORITY;
     }
 
     /**


### PR DESCRIPTION
Issue Resolved - SpotBugs - Overridable method getCriticKey is called from constructor in org.argouml.cognitive.Critic() https://github.com/rilling/argoumlFall2024/issues/77



_**Type of Vulnerability**_

- Source Code Analysis Tool - Spotbug
-  MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR
- MC: An overridable method is called from a constructor (MC_OVERRIDABLE_METHOD_CALL_IN_CONSTRUCTOR)
Calling an overridable method during in a constructor may result in the use of uninitialized data. It may also leak the this reference of the partially constructed object. Only static, final or private methods should be invoked from a constructor.
See SEI CERT rule [MET05-J. Ensure that constructors do not call overridable methods](https://wiki.sei.cmu.edu/confluence/display/java/MET05-J.+Ensure+that+constructors+do+not+call+overridable+methods).


_**Code before refactoring**_
![image](https://github.com/user-attachments/assets/9ad3f6bd-3302-48fc-b4cd-49c42f1920e9)

![image](https://github.com/user-attachments/assets/3069e280-18e9-4dbf-bcdb-486d8685d021)

_**Additional context**_
SPOTBUG REPORT

![image](https://github.com/user-attachments/assets/5ec59cef-0748-4d48-a5b6-1849c08d07a8)
